### PR TITLE
Cleaned up client-async spawning

### DIFF
--- a/client_async/src/main.rs
+++ b/client_async/src/main.rs
@@ -6,7 +6,6 @@ use std::error::Error;
 use std::thread::sleep;
 use std::time::Instant;
 #[allow(unused_imports)]
-use tokio::join;
 use tokio::net::TcpStream;
 use tokio::prelude::*;
 
@@ -26,33 +25,40 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     // task("task3", now.clone()).await?;
 
     // Asynchronous single-thread
-    // let mut futs = FuturesUnordered::new();
-
-    // futs.push(task("task1", now.clone()));
-    // futs.push(task("task2", now.clone()));
-    // futs.push(task("task3", now.clone()));
-
-    // while let Some(_handled) = futs.next().await {}
+    /*
+    let mut futs = FuturesUnordered::new();
+    futs.push(task("task1", now.clone()));
+    futs.push(task("task2", now.clone()));
+    futs.push(task("task3", now.clone()));
+    while let Some(handled) = futs.next().await {
+        handled?;
+    }
+    Ok(())
+    */
 
     // Asynchronous multi-threaded
-    // let mut futs = FuturesUnordered::new();
-    // futs.push(tokio::spawn(task("task1", now.clone())));
-    // futs.push(tokio::spawn(task("task2", now.clone())));
-    // futs.push(tokio::spawn(task("task3", now.clone())));
-    // while let Some(_handled) = futs.next().await {}
+    /*
+    let mut futs = FuturesUnordered::new();
+    futs.push(tokio::spawn(task("task1", now.clone())));
+    futs.push(tokio::spawn(task("task2", now.clone())));
+    futs.push(tokio::spawn(task("task3", now.clone())));
+    while let Some(handled) = futs.next().await {
+        handled??;
+    }
+    Ok(())
+    */
 
     // Equivalent to FuturesUnordered, but without allocation, less wieldy for many futures
-    match join!(
+    match futures::future::join3(
         tokio::spawn(task("task1", now.clone())),
         tokio::spawn(task("task2", now.clone())),
         tokio::spawn(task("task3", now.clone()))
-    ) {
+    ).await {
         (x, y, z) => {
             // dbg!("{:?}", (&x, &y, &z));
-            (x.ok(), y.ok(), z.ok())
+            x??; y??; z?
         }
-    };
-    Ok(())
+    }
 }
 
 async fn task(


### PR DESCRIPTION
* Modified task spawning to check for errors and return an appropriate result from main.

* Replaced tokio `join!()` with futures `join3()` for clarity and runtime portability.

* Changed commented-out spawning source in `client_async/src/main.rs` to use `/* */` for ease of modification.

If this is merged, you may also be interested in my [async-std](https://github.com/BartMassey/async-rust-example/tree/async-std) branch built on it, which (as the name implies) has been modified to use `async-std` instead of `tokio`. I did it as an exercise for comparison purposes. I didn't want to put in a pull request myself, since it should probably remain on a separate branch and I didn't know how to ask for that with a GitHub pull request.