### PR TITLE
Changed to use async-std instead of tokio

### DIFF
--- a/client_async/Cargo.toml
+++ b/client_async/Cargo.toml
@@ -7,5 +7,8 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "0.2.20", features = ["full"] }
 futures = "0.3.4"
+
+[dependencies.async-std]
+version = "1.6.0-beta.1"
+features = ["unstable", "attributes"]

--- a/client_async/src/main.rs
+++ b/client_async/src/main.rs
@@ -4,18 +4,16 @@ use futures::stream::futures_unordered::FuturesUnordered;
 use futures::stream::StreamExt;
 use std::error::Error;
 use std::thread::sleep;
-use std::time::Instant;
+use std::time::{Instant, Duration};
 #[allow(unused_imports)]
-use tokio::net::TcpStream;
-use tokio::prelude::*;
+use async_std::net::TcpStream;
+use async_std::prelude::*;
 
 // Synchronous: (2+8+4) * 3 = 42 secs
 // Async single-thread: 2 + 8 + (3*4) = 22 secs
 // Async multi-thread (>3 threads): 2 + 8 + 4 = 14 secs
 
-// #[tokio::main(core_threads = 1, max_threads = 1)] // Single thread
-//
-#[tokio::main]
+#[async_std::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let now = Instant::now();
 
@@ -39,24 +37,24 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     // Asynchronous multi-threaded
     /*
     let mut futs = FuturesUnordered::new();
-    futs.push(tokio::spawn(task("task1", now.clone())));
-    futs.push(tokio::spawn(task("task2", now.clone())));
-    futs.push(tokio::spawn(task("task3", now.clone())));
+    futs.push(async_std::task::spawn(task("task1", now.clone())));
+    futs.push(async_std::task::spawn(task("task2", now.clone())));
+    futs.push(async_std::task::spawn(task("task3", now.clone())));
     while let Some(handled) = futs.next().await {
-        handled??;
+        handled?;
     }
     Ok(())
     */
 
     // Equivalent to FuturesUnordered, but without allocation, less wieldy for many futures
     match futures::future::join3(
-        tokio::spawn(task("task1", now.clone())),
-        tokio::spawn(task("task2", now.clone())),
-        tokio::spawn(task("task3", now.clone()))
+        async_std::task::spawn(task("task1", now.clone())),
+        async_std::task::spawn(task("task2", now.clone())),
+        async_std::task::spawn(task("task3", now.clone()))
     ).await {
         (x, y, z) => {
             // dbg!("{:?}", (&x, &y, &z));
-            x??; y??; z?
+            x?; y?; z
         }
     }
 }
@@ -65,14 +63,14 @@ async fn task(
     label: &'static str,
     now: std::time::Instant,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
-    // Simulate network delay using Tokio async delay for 2 seconds
+    // Simulate network delay using async delay for 2 seconds
     println!(
         "OS Thread {:?} - {} started: {:?}",
         std::thread::current().id(),
         label,
         now.elapsed(),
     );
-    tokio::time::delay_for(tokio::time::Duration::from_secs(2)).await;
+    async_std::task::sleep(Duration::from_secs(2)).await;
 
     // Write to server - server will echo this back to us with 8 second delay
     let mut stream = TcpStream::connect("127.0.0.1:6142").await?;

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -8,5 +8,10 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "0.2.20", features = ["full"] }
 futures = "0.3.4"
+futures-util = "0.3.5"
+
+[dependencies.async-std]
+version = "1.6.0-beta.1"
+features = ["unstable", "attributes"]
+

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,10 +1,12 @@
+use futures_util::io::AsyncReadExt;
 use futures::stream::StreamExt;
-use tokio::net::TcpListener;
+use async_std::net::TcpListener;
+use std::time::Duration;
 
-#[tokio::main]
+#[async_std::main]
 async fn main() {
     let addr = "127.0.0.1:6142";
-    let mut listener = TcpListener::bind(addr).await.unwrap();
+    let listener = TcpListener::bind(addr).await.unwrap();
 
     let server = {
         async move {
@@ -12,11 +14,11 @@ async fn main() {
             while let Some(conn) = incoming.next().await {
                 match conn {
                     Err(e) => eprintln!("accept failed = {:?}", e),
-                    Ok(mut sock) => {
-                        tokio::spawn(async move {
+                    Ok(sock) => {
+                        async_std::task::spawn(async move {
                             let (mut reader, mut writer) = sock.split();
-                            tokio::time::delay_for(tokio::time::Duration::from_secs(8)).await;
-                            match tokio::io::copy(&mut reader, &mut writer).await {
+                            async_std::task::sleep(Duration::from_secs(8)).await;
+                            match async_std::io::copy(&mut reader, &mut writer).await {
                                 Ok(amt) => {
                                     println!("wrote {} bytes", amt);
                                 }


### PR DESCRIPTION
This branch contains changes to use `async-std` instead of `tokio`. **It should probably be pulled onto its own branch rather than onto master.** Unfortunately, Github seems to have no way to request this from my end.